### PR TITLE
RIL: Permit single-SIM mode on dual-SIM devices

### DIFF
--- a/init.carrier.rc
+++ b/init.carrier.rc
@@ -26,10 +26,15 @@
 #
 on boot
 
+# Dual-sim support
+on property:persist.radio.multisim.config=dsds
+    start ril-daemon2 
+    
 # for multi rild
 service ril-daemon2 /system/bin/rild -s rild2 -ds rild-debug1 -l /system/lib/libsec-ril-dsds.so
     class main
     socket rild2 stream 660 root radio
     socket rild-debug1 stream 660 radio system
     user root
+    disabled 
     group radio cache inet misc audio log qcom_diag sdcard_r shell sdcard_rw system drmrpc


### PR DESCRIPTION
We can toggle ril in single-SIM mode by using these changes in build.prop:
https://github.com/k2wl/android_device_samsung_serranodsdd/commit/5e1e442a224b6244ffed953a5c727f2161cdc896
But service ril-daemon2 will be always started
This patch makes solving this issue
